### PR TITLE
Fix name clash and ConnectionClosed exception in Client.connect method

### DIFF
--- a/steam/ext/csgo/client.py
+++ b/steam/ext/csgo/client.py
@@ -44,7 +44,7 @@ class Client(Client_):
     async def connect(self):
         async def ping():
             await self.wait_until_ready()
-            while True:
+            while not self.is_closed():
                 await self.ws.send_gc_message(GCMsgProto(Language.ClientHello))
                 await asyncio.sleep(30)
 

--- a/steam/ext/csgo/client.py
+++ b/steam/ext/csgo/client.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import ClassVar
 
 from ... import utils
-from ...client import Client
+from ...client import Client as Client_
 from ...ext import commands
 from ...game import CSGO, Game
 from .enums import Language
@@ -21,7 +21,7 @@ __all__ = (
 from ...protobufs import GCMsgProto
 
 
-class Client(Client):
+class Client(Client_):
     GAME: ClassVar = CSGO
     user: ClientUser
 


### PR DESCRIPTION
Hi! I really like your work, so thank you for that!
I found, that little annoying moment - my Pycharm code inspection didn't work properly, so i decided to fix it.
Also, while i closed the client, connect method always throws **ConnectionReset** exception. After some inspection i made sure that problem was there:
```python
async def connect(self):
    async def ping():
        await self.wait_until_ready()
        while True:   # <- and there
            await self.ws.send_gc_message(GCMsgProto(Language.ClientHello))   # <- there
            await asyncio.sleep(30)

    await asyncio.gather(
        super().connect(),
        ping(),
    )
```
Unconditional while loop working and coroutine even after client is closed, expectedly, send message to GC trougth closed connection that throws error. I offer simple solution - check **is_closed()** in while. By the way, you already do this in connect method of **steam.Client:**
```python
  while not self.is_closed():  # there :)
      last_connect = time.monotonic()

      try:
          self.ws = await asyncio.wait_for(SteamWebSocket.from_client(self, cm_list=self._cm_list), timeout=60)
      except exceptions:
          await throttle()
          continue
```
I will be grateful if you accept this PR :)