### PR TITLE
Implement `inspect_item` and `inspect_url`

### DIFF
--- a/steam/ext/csgo/backpack.py
+++ b/steam/ext/csgo/backpack.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 from typing import TYPE_CHECKING
-
+ 
 from ... import utils
 from ...utils import make_id64
 from ...protobufs import GCMsgProto

--- a/steam/ext/csgo/backpack.py
+++ b/steam/ext/csgo/backpack.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 from typing import TYPE_CHECKING
- 
+  
 from ... import utils
 from ...utils import make_id64
 from ...protobufs import GCMsgProto

--- a/steam/ext/csgo/backpack.py
+++ b/steam/ext/csgo/backpack.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from ... import utils
-from ...abc import SteamID
+from ...utils import make_id64
 from ...protobufs import GCMsgProto
 from ...trade import BaseInventory, Inventory, Item
 from .enums import ItemCustomizationNotification as ItemCustomizationNotificationEnum, Language
@@ -113,14 +113,14 @@ class BackpackItem(Item):
     @property
     def inspect_url(self) -> str | None:
         """
-        Get inspect url of item if it `inspectable` or None
-        :return: str or None
+        Get inspect url of item if it `inspectable`
+        :return: Inspect url or None
         """
         try:
             for action in self.actions or []:
                 if "inspect" in action["name"].lower():
                     return (action["link"]
-                            .replace('%owner_steamid%', str(self._state.client.user.id64))
+                            .replace('%owner_steamid%', str(make_id64(self.account_id)))
                             .replace('%assetid%', str(self.id)))
 
         except (ValueError, KeyError):

--- a/steam/ext/csgo/backpack.py
+++ b/steam/ext/csgo/backpack.py
@@ -117,7 +117,7 @@ class BackpackItem(Item):
         :return: Inspect url or None
         """
         try:
-            for action in self.actions or []:
+            for action in self.actions:
                 if "inspect" in action["name"].lower():
                     return (action["link"]
                             .replace('%owner_steamid%', str(make_id64(self.account_id)))

--- a/steam/ext/csgo/backpack.py
+++ b/steam/ext/csgo/backpack.py
@@ -110,12 +110,21 @@ class BackpackItem(Item):
                     break
         return contained_items
 
-    async def inspect(
-        self,
-        owner: SteamID,
-        d: str,
-    ):
-        ...
+    @property
+    def inspect_url(self) -> str | None:
+        """
+        Get inspect url of item if it `inspectable` or None
+        :return: str or None
+        """
+        try:
+            for action in self.actions or []:
+                if "inspect" in action["name"].lower():
+                    return (action["link"]
+                            .replace('%owner_steamid%', str(self._state.client.user.id64))
+                            .replace('%assetid%', str(self.id)))
+
+        except (ValueError, KeyError):
+            return None
 
 
 class Backpack(BaseInventory[BackpackItem]):

--- a/steam/ext/csgo/client.py
+++ b/steam/ext/csgo/client.py
@@ -82,7 +82,6 @@ class Client(Client_):
             d: int = 0,
             market_id: int = 0,
             url: str = "",
-            _timeout: int = 10
     ) -> PreviewDataBlock:
         """
         The parameters can be taken from `inspect` links either from an inventory or market.
@@ -116,7 +115,7 @@ class Client(Client_):
 
         return await self.wait_for(
             "inspect_item_info",
-            timeout=_timeout,
+            timeout=60.0,
             check=lambda item: item.itemid == asset_id
         )
 

--- a/steam/ext/csgo/client.py
+++ b/steam/ext/csgo/client.py
@@ -63,7 +63,7 @@ class Client(Client_):
         await super()._handle_ready()
 
     @overload
-    async def inspect_item(self, *, owner: Type[SteamID], asset_id: int, d: int) -> PreviewDataBlock:
+    async def inspect_item(self, *, owner: SteamID, asset_id: int, d: int) -> PreviewDataBlock:
         ...
 
     @overload
@@ -113,13 +113,15 @@ class Client(Client_):
         if s == 0 and m == 0:
             raise TypeError(f"Missing required keyword-only argument: {'s' if not s else 'm'}")
 
-        params = {
-            'param_s': s,
-            'param_a': a,
-            'param_d': d,
-            'param_m': m,
-        }
-        await self.ws.send_gc_message(GCMsgProto(Language.Client2GCEconPreviewDataBlockRequest, **params))
+        await self.ws.send_gc_message(
+            GCMsgProto(
+                    Language.Client2GCEconPreviewDataBlockRequest,
+                    param_s=s,
+                    param_a=a
+                    param_d=d,
+                    param_m=m,
+                )
+        )
 
         return await self.wait_for(
             "inspect_item_info",

--- a/steam/ext/csgo/client.py
+++ b/steam/ext/csgo/client.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+import re
+from typing import TYPE_CHECKING, Any, overload, Type
 
 from typing_extensions import ClassVar
 
@@ -9,9 +10,11 @@ from ... import utils
 from ...client import Client as Client_
 from ...ext import commands
 from ...game import CSGO, Game
+from ...abc import SteamID
 from .enums import Language
 from .models import ClientUser, User
 from .state import GCState
+from .protobufs.cstrike import PreviewDataBlock
 
 __all__ = (
     "Client",
@@ -24,6 +27,7 @@ from ...protobufs import GCMsgProto
 class Client(Client_):
     GAME: ClassVar = CSGO
     user: ClientUser
+    _connection: GCState
 
     def __init__(self, **options: Any):
         game = options.pop("game", None)
@@ -57,6 +61,71 @@ class Client(Client_):
         self._connection._unpatched_inventory = self.user.inventory
         self.http.user = ClientUser(self._connection, await self.http.get_user(self.user.id64))
         await super()._handle_ready()
+
+    @overload
+    async def inspect_item(self, *, owner: Type[SteamID], asset_id: int, d: int) -> PreviewDataBlock:
+        ...
+
+    @overload
+    async def inspect_item(self, *, s: int, a: int, d: int) -> PreviewDataBlock:
+        ...
+
+    @overload
+    async def inspect_item(self, *, m: int, a: int, d: int) -> PreviewDataBlock:
+        ...
+
+    @overload
+    async def inspect_item(self, *, url: str) -> PreviewDataBlock:
+        ...
+
+    async def inspect_item(
+            self,
+            *,
+            owner: SteamID | None = None,
+            asset_id: int | None = None,
+            s: int = 0,
+            a: int = 0,
+            d: int = 0,
+            m: int = 0,
+            url: str = "",
+            timeout: int=10
+    ) -> PreviewDataBlock:
+        """
+        The parameters can be taken from `inspect` links either from an inventory or market.
+        The market has the `m` parameter, while the inventory one has `s`.
+        :param s: steam id64 of owner
+        :param a: item (asset) id
+        :param d: inspect id (Unknown d number)
+        :param m: market id
+        """
+        if owner:
+            s = owner.id64
+        if asset_id:
+            a = asset_id
+
+        if url:
+            search = re.search(r'[SM](\d+)A(\d+)D(\d+)$', url)
+            s = int(search[1]) if search[0].startswith("S") else 0
+            m = int(search[1]) if search[0].startswith("M") else 0
+            a = int(search[2])
+            d = int(search[3])
+
+        if s == 0 and m == 0:
+            raise TypeError(f"Missing required keyword-only argument: {'s' if not s else 'm'}")
+
+        params = {
+            'param_s': s,
+            'param_a': a,
+            'param_d': d,
+            'param_m': m,
+        }
+        await self.ws.send_gc_message(GCMsgProto(Language.Client2GCEconPreviewDataBlockRequest, **params))
+
+        return await self.wait_for(
+            "inspect_item_info",
+            timeout=timeout,
+            check=lambda item: item.itemid == a
+        )
 
     if TYPE_CHECKING:
 

--- a/steam/ext/csgo/protobufs/__init__.py
+++ b/steam/ext/csgo/protobufs/__init__.py
@@ -12,6 +12,7 @@ PROTOBUFS.update(
         Language.MatchmakingGC2ClientHello: cstrike.MatchmakingClientHello,
         Language.MatchList: cstrike.MatchList,
         Language.PlayersProfile: cstrike.PlayersProfile,
+        Language.Client2GCEconPreviewDataBlockRequest: cstrike.Client2GcEconPreviewDataBlockRequest,
         Language.Client2GCEconPreviewDataBlockResponse: cstrike.Client2GcEconPreviewDataBlockResponse,
         Language.ItemCustomizationNotification: econ.ItemCustomizationNotification,
         Language.CasketItemLoadContents: econ.CasketItem,

--- a/steam/ext/csgo/state.py
+++ b/steam/ext/csgo/state.py
@@ -216,10 +216,9 @@ class GCState(ConnectionState):
     @register(Language.Client2GCEconPreviewDataBlockResponse)
     def handle_client_preview_data_block_response(self, msg: GCMsgProto[cstrike.Client2GcEconPreviewDataBlockResponse]):
         # decode the wear
-        with utils.StructIO() as io:
-            io.write_u32(msg.body.iteminfo.paintwear)
-            item = utils.get(self.backpack, id=msg.body.iteminfo.itemid)
-            item.paint_wear = io.read_f32()
+        item = msg.body.iteminfo
+        packed_wear = struct.pack(">l", msg.body.iteminfo.paintwear)
+        item.paintwear = struct.unpack(">f", packed_wear)[0]
         self.dispatch("inspect_item_info", item)
 
     @register(Language.ItemCustomizationNotification)


### PR DESCRIPTION
I hope my code good enough. Also, i don't know why decoding of wear wont work(and don't understand what the `utils.StructIO` should do). Throws error:
```sh
Traceback (most recent call last):
  File "...\steam-ext-csgo\steam\utils.py", line 732, in maybe_coroutine
    value = func(*args, **kwargs)
  File "...\steam-ext-csgo\steam\ext\csgo\state.py", line 230, in handle_client_preview_data_block_response
    item.paint_wear = io.read_f32()
  File "<string>", line 1, in read_f32
  File "...\steam-ext-csgo\steam\utils.py", line 601, in read_struct
    return struct.unpack(format, buffer)
struct.error: unpack requires a buffer of 4 bytes
```
Tested on windows 10 x64, python 3.10; docker image `python3:10-slim-buster` and `python3:10` - same result. So i simply fix it by use `struct.pack/unpack`. I decided to return `protobufs.cstrike.PreviewDataBlock` from inspect (similar to [DoctorMcKay csgo inspectItem](https://github.com/DoctorMcKay/node-globaloffensive#inspectitemowner-assetid-d-callback)) and i really would be tnank if you point me out if i did something wrong