### PR TITLE
Back to stable versions of poetry-core since v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,5 +86,5 @@ reportUnnecessaryComparison = true
 reportUnnecessaryContains = true
 
 [build-system]
-requires = ["poetry-core==1.1.0a7"]  # ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
https://pypi.org/project/poetry-core/1.1.0a7/ was still being forced as the dependency version, but anything since https://pypi.org/project/poetry-core/1.1.0/ should support groups (which is why 7fef2acc9e7604ce312fed04d7122b3602381aac was done originally)